### PR TITLE
Fix up changesets template

### DIFF
--- a/templates/changesets.yml
+++ b/templates/changesets.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          persist-credentials: true
+          persist-credentials: false
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 24


### PR DESCRIPTION
This PR tweaks the changesets template to provide it with the required permissions and includes a workaround for OIDC trusted publisher set-up where the `NPM_TOKEN` input needs to be set to an empty string.

Follow up to https://github.com/e18e/e18e/issues/140